### PR TITLE
add Unwrap()

### DIFF
--- a/lmw.go
+++ b/lmw.go
@@ -131,3 +131,10 @@ func (rw *responseWriter) Write(response []byte) (int, error) {
 	rw.size += int64(n)
 	return n, err
 }
+
+// Unwrap exposes the underlying writer so http.ResponseController can navigate
+// past this wrapper to find Flusher / Hijacker / etc. on the original writer.
+// Without this, SSE handlers downstream lose Flush() and can't stream.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}


### PR DESCRIPTION
## Summary
Adds `Unwrap() http.ResponseWriter` to the logging middleware's response wrapper so `http.ResponseController` can navigate past it to find `Flusher`, `Hijacker`, and other interfaces on the underlying writer. Without this, any SSE/streaming handler downstream of `DurationLoggingMiddleware` cannot flush and either errors out or silently truncates.

### Background
`DurationLoggingMiddleware` wraps `http.ResponseWriter` in `*responseWriter` to capture the status code and response size for logging. The wrapper embeds `http.ResponseWriter` but the embedded interface doesn't expose `Flush`/`Hijack`/`Push`, so a downstream `w.(http.Flusher)` type assertion fails. The standard-library remedy is for wrappers to implement `Unwrap() http.ResponseWriter`, which `http.ResponseController` follows.

### Discovered via
A new SSE endpoint (`GET /jobs/queues/{queue}/jobs/{jobId}/watch`) in `transitland-lib`'s jobserver returned an empty body when mounted in tlv2's middleware chain — the chain includes this logging middleware, which was breaking `Flush()`.

## Test plan
- Unit: existing `lmw_test.go` continues to pass.
- Manual: in tlv2 with `--enable-jobs-api`, confirm `curl -N $BASE/queues/$Q/jobs/$JOB_ID/watch` against an already-terminal job emits the terminal event and `event: end` sentinel before the connection closes. Before this change, the body was empty.
