### PR TITLE
TL_LOG_QUERIES

### DIFF
--- a/log.go
+++ b/log.go
@@ -45,6 +45,21 @@ func TraceCheck(fn func()) {
 	}
 }
 
+// queryLogging gates per-query database logging. It is off by default so enabling
+// TRACE-level logging doesn't flood with one line per query; set TL_LOG_QUERIES=true
+// (or call SetLogQueries) to turn it on.
+var queryLogging = os.Getenv("TL_LOG_QUERIES") == "true"
+
+// LogQueries reports whether per-query database logging is enabled (TL_LOG_QUERIES).
+func LogQueries() bool {
+	return queryLogging
+}
+
+// SetLogQueries enables or disables per-query database logging at runtime.
+func SetLogQueries(v bool) {
+	queryLogging = v
+}
+
 // Zerolog simple wrappers
 
 // Error for notable errors.


### PR DESCRIPTION
## Summary

Adds an opt-in gate for per-query database logging. Previously, enabling TRACE-level logging would emit one line per query, flooding output. This introduces a separate `TL_LOG_QUERIES` switch so query logging can be turned on independently and stays off by default.

## Changes

- New package-level `queryLogging` flag, initialized from `TL_LOG_QUERIES=true` (off by default)
- `LogQueries() bool` — reports whether per-query logging is enabled
- `SetLogQueries(bool)` — toggles it at runtime

## Notes

Callers that emit per-query logs should gate them on `log.LogQueries()`. Default behavior is unchanged — query logging stays silent unless explicitly enabled via the env var or `SetLogQueries`.
