### PR TITLE
Pin actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,5 +18,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.21.5'
+          go-version: '1.24.0'
       - run: go test -v -count=1 ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.21.5'
       - run: go test -v -count=1 ./...


### PR DESCRIPTION
## Summary

Pins GitHub Actions to full commit SHAs to satisfy the org security requirement (failing builds previously used floating tags). Matches the convention already used in `transitland-lib`.

## Changes

- Pin `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- Pin `actions/setup-go` → `4a3601121dd01d1626a1e23e37211e3254c1c06c` (v6.4.0)
- Add top-level `permissions: contents: read` for a least-privilege `GITHUB_TOKEN`
- Bump CI `go-version` `1.21.5` → `1.24.0` to match `go.mod` (CI was failing with `requires go >= 1.24.0`)

## Verification

`go test -count=1 ./...` passes locally on Go 1.24.1.